### PR TITLE
enable key vault provider and workload identities on aks cluster

### DIFF
--- a/base-infrastructure/terraform/resources/aks.tf
+++ b/base-infrastructure/terraform/resources/aks.tf
@@ -1,7 +1,7 @@
 resource "azurerm_kubernetes_cluster" "ifrcgo" {
-  lifecycle {
-    ignore_changes = all
-  }
+#  lifecycle {
+#    ignore_changes = all
+#  }
   
   name                = "${local.prefix}-cluster"
   location            = data.azurerm_resource_group.ifrcgo.location
@@ -27,6 +27,14 @@ resource "azurerm_kubernetes_cluster" "ifrcgo" {
     Environment = var.environment
     ManagedBy   = "IFRCGo"
   }
+
+  key_vault_secrets_provider {
+    secret_rotation_enabled  = true
+    secret_rotation_interval = var.secret_rotation_interval
+  }
+
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
 }
 
 # add the role to the identity the kubernetes cluster was assigned

--- a/base-infrastructure/terraform/resources/variables.tf
+++ b/base-infrastructure/terraform/resources/variables.tf
@@ -21,6 +21,18 @@ variable "RESOURCES_DB_SERVER" {
   default = ""
 }
 
+variable "secret_rotation_interval" {
+  type        = string
+  description = "How frequently the cluster should check for secret changes in minutes, in the form of '2m', '3m', etc."
+  default     = "2m"
+
+  validation {
+    condition     = can(regex("^[1-9][0-9]*m$", var.secret_rotation_interval))
+    error_message = "The secret_rotation_interval value must be a string in the form of 'Xm' where X is a positive integer, e.g., '2m', '10m', etc."
+  }
+}
+
+
 # -----------------
 # Attach ACR
 # Defaults to common resources


### PR DESCRIPTION
# Enable Azure Key Vault Provider and Workload Identities on AKS Cluster

## Description

This PR introduces the following changes to the AKS cluster:

1. **Azure Key Vault Provider**: Integrates the Azure Key Vault provider to allow AKS workloads to access secrets stored in Azure Key Vault securely.
   
2. **Workload Identities**: Enables Azure AD workload identities, allowing AKS pods to authenticate with Azure AD and securely access Azure resources (e.g., Key Vault) without managing service principal secrets.

## Motivation

- **Operational Efficiency**: This integration simplifies the secret management process. AKS workloads will be able to access specific secret vaults. K8s manifests can then be used in helm charts that directly access secrets. Dynamic reloading of pods will be possible when secrets are edited on the Azure Key Vault, negating the need to re-run deploy pipelines.


## Changes Made

- **Key Vault Provider Configuration**:
  - Added `azure-keyvault-secrets` provider in AKS configuration.
  
- **Workload Identities**:
  - Enabled workload identity usage in the AKS Terraform module.

## Related Issues
[Issue #16](https://github.com/IFRCGo/go-deploy/issues/16#issue-2573572652)
