### PR TITLE
Feature/argocd setup

### DIFF
--- a/applications/argocd/staging/platform/image-updater.yaml
+++ b/applications/argocd/staging/platform/image-updater.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-image-updater
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://argoproj.github.io/argo-helm
+    chart: argocd-image-updater
+    targetRevision: "0.11.0"
+    helm:
+      values: |
+        config:
+          registries:
+            - name: ghcr.io
+              api_url: https://ghcr.io
+              prefix: ghcr.io
+              credentials: pullSecret:argocd/ghcr-secret
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/applications/argocd/staging/platform/reloader.yaml
+++ b/applications/argocd/staging/platform/reloader.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reloader
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://stakater.github.io/stakater-charts
+    chart: reloader
+    targetRevision: 1.1.0
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: reloader
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/base-infrastructure/terraform/resources/helm-argocd.tf
+++ b/base-infrastructure/terraform/resources/helm-argocd.tf
@@ -1,0 +1,24 @@
+resource "helm_release" "argo-cd" {
+  name             = "argo-cd"
+  chart            = "argo-cd"
+  create_namespace = true
+
+  depends_on = [
+    azurerm_kubernetes_cluster.ifrcgo
+  ]
+
+  repository = "https://argoproj.github.io/argo-helm"
+  namespace  = "argocd"
+  version    = "7.6.7"
+
+  values = [
+    yamlencode({
+      configs = {
+        cm = {
+          "timeout.reconciliation": "60s"  
+          "timeout.hard.reconciliation": "90s"
+        }
+      }
+    })
+  ]
+}


### PR DESCRIPTION
# Pull Request: Add ArgoCD to Kubernetes Cluster with Terraform and 'App of Apps' Structure 

## Summary  
This pull request introduces ArgoCD to the Kubernetes cluster using the `helm_release` resource in Terraform. It also establishes a new directory structure (`applications/argocd/staging/`) to organize ArgoCD applications in the [**App of Apps**](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/)  pattern. This implementation lays the foundation for managing applications and platform utilities via ArgoCD, enabling streamlined deployment, configuration, and synchronization.  

## Changes  
1. **Terraform Changes:**  
   - Added a `helm_release` resource in Terraform resources module to deploy ArgoCD to the cluster.  
   - Configured default synchronization period.  

2. **Directory Structure:**  
   - `applications/argocd/staging/applications/`: Shall contain IFRC application definitions managed by ArgoCD.  
   - `applications/argocd/staging/platform/`: Contains utilities like `argocd-image-updater` and `stakater.reloader` applicable across the cluster.  

3. **App of Apps Pattern:**  
   - Created base ArgoCD application manifests under `applications/argocd/staging/` to implement the App of Apps pattern for hierarchical application management.  

## Issue Resolved  
This PR is related [Issue #20 ](#) by integrating ArgoCD into the Kubernetes cluster and providing a scalable structure for managing applications in the staging environment.

## Justification  
- **Centralized Application Management:** ArgoCD simplifies application lifecycle management (deployment, synchronization, rollback) within the cluster.  
- **Scalable and Modular:** The App of Apps pattern facilitates modular and hierarchical management of applications, making it easy to extend configurations for new environments.  
- **Cluster-Wide Utilities:** Utilities like `argocd-image-updater` and `stakater.reloader` improve operational efficiency by automating image updates and configuration reloads.  

## Next Steps  
To finalize the App of Apps setup, we shall follow these steps using the ArgoCD graphical interface:  

1. Log in to the ArgoCD web interface.  
2. Create a new ArgoCD application:  
   - **Name:** `staging-app-of-apps`  
   - **Project:** `default`  
   - **Sync Policy:** Set to auto-sync if desired.  
   - **Repository URL:** `https://github.com/IFRCGo/go-deploy`  
   - **Revision:** `develop`  
   - **Path:** `applications/argocd/staging/`  
   - **Destination:**  
     - **Cluster URL:** `https://kubernetes.default.svc`  
     - **Namespace:** `argocd`  
3. Save and sync the application. This action will recursively apply all applications defined within the `staging` folder.  
4. Verify the successful creation of child applications under the **Applications** view.  
5. Test platform utilities like `argocd-image-updater` and `stakater.reloader` to ensure proper configuration.  

## Testing  
- Verified that the `helm_release` resource applies successfully and creates ArgoCD resources in the cluster on sandbox.  
- Tested App of Apps manifests to ensure child applications are correctly managed on sandbox.  
- Confirmed functionality of `argocd-image-updater` and `stakater.reloader` after deployment on sandbox.  

## Additional Notes  
- Ensure secrets required by the platform utilities are properly created in the `argocd` namespace. Specifically, the registry secret used by image updater 
- Future PRs can expand the application structure to include production and other environments.  

---

**Ready for review and deployment.**
