### PR TITLE
Deploy eoapi instance for Montandon through ArgoCD

### DIFF
--- a/applications/argocd/staging/applications/montandon-eoapi.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: montandon-eoapi
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://devseed.com/eoapi-k8s/
+    chart: eoapi
+    targetRevision: 0.5.0
+    helm:
+      valuesObject:
+        ingress:
+          host: "montandon-eoapi-stage.ifrc.org"
+          tls:
+            enabled: false
+        pgstacBootstrap:
+          settings:
+            envVars:
+              LOAD_FIXTURES: "0"
+              RUN_FOREVER: "1"
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: montandon-eoapi
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/applications/argocd/staging/applications/montandon-eopai-pgo.yaml
+++ b/applications/argocd/staging/applications/montandon-eopai-pgo.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: montandon-eoapi-pgo
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: registry.developers.crunchydata.com/crunchydata
+    chart: pgo
+    targetRevision: 5.5.2
+    helm:
+      valuesObject:
+        disable_check_for_upgrades: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: montandon-eoapi
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
@szabozoltan69 @Lusengeri Would you be able to take a look if this looks alright? 

@szabozoltan69 Could we set up a URL that directs to this ingress for the eoapi instance? Right now, I'm using `montandon-eoapi-stage.ifrc.org` as the URL. Feel free to suggest any changes. I've left TLS disabled to keep things uncomplicated for now.