### PR TITLE
Reduce cpu request for api deployment

### DIFF
--- a/applications/go-api/helm/ifrcgo-helm/values-production.yaml
+++ b/applications/go-api/helm/ifrcgo-helm/values-production.yaml
@@ -24,7 +24,7 @@ api:
   replicaCount: 2
   resources:
     requests:
-      cpu: "2"
+      cpu: "1"
       memory: 4Gi
     limits:
       cpu: "2"


### PR DESCRIPTION
keep cpu request low to optimize pod scheduling to fully utilize available cpu on k8s nodes