### PR TITLE
Bump up memory request for GO prod api

### DIFF
--- a/applications/go-api/azure-pipelines.yaml
+++ b/applications/go-api/azure-pipelines.yaml
@@ -32,7 +32,7 @@ jobs:
     displayName: "Deploy staging instance of go-api"
     env:
       ENVIRONMENT: staging
-      VERSION: "0.0.1-0.dev.git.1.hd096c10"
+      VERSION: "0.0.1-0.dev.git.1.h6bb5902"
       # For Azure CLI
       AZURE_TENANT_ID: $(TERRAFORM_TENANT_ID)
       AZURE_CLIENT_ID: $(TERRAFORM_SERVICE_PRINCIPAL_ID)

--- a/applications/go-api/helm/ifrcgo-helm/values-production.yaml
+++ b/applications/go-api/helm/ifrcgo-helm/values-production.yaml
@@ -25,7 +25,7 @@ api:
   resources:
     requests:
       cpu: "1"
-      memory: 2Gi
+      memory: 4Gi
     limits:
       cpu: "2"
       memory: 4Gi


### PR DESCRIPTION
we're seeing weird SIGKILL errors in gunicorn logs and healthcheck timeouts in k8s logs.