### PR TITLE
Bump up Montandon eoapi database storage

### DIFF
--- a/applications/argocd/staging/applications/montandon-eoapi.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi.yaml
@@ -31,7 +31,7 @@ spec:
               - "ReadWriteOnce"
               resources:
                 requests:
-                  storage: "250Gi"
+                  storage: "500Gi"
                   cpu: "1024m"
                   memory: "3048Mi"
 


### PR DESCRIPTION
bumping up storage to 500 GB