### PR TITLE
Feature/add acr container registry

### DIFF
--- a/base-infrastructure/terraform/app_resources.tf
+++ b/base-infrastructure/terraform/app_resources.tf
@@ -62,3 +62,28 @@ module "alert_hub_resources" {
     "32053268-3970-48f3-9b09-c4280cd0b67d"
   ]
 }
+
+module "sdt_resources" {
+  source = "./app_resources"
+
+  app_name            = "sdt"
+  environment         = var.environment
+  resource_group_name = module.resources.resource_group
+
+  aks_config = {
+    cluster_namespace       = "sdt"
+    cluster_oidc_issuer_url = module.resources.cluster_oidc_issuer_url
+    service_account_name    = "service-token-reader"
+  }
+
+  secrets = {
+    REGISTRY_LOGIN_SERVER = module.go_shared_registry.registry_server
+    REGISTRY_PASSWORD     = module.go_shared_registry.acr_token_password
+    REGISTRY_USER         = module.go_shared_registry.acr_token_username
+  }
+
+  vault_admin_ids = [
+    "c31baae7-afbf-4ad3-8e01-5abbd68adb16",
+    "32053268-3970-48f3-9b09-c4280cd0b67d"
+  ]
+}

--- a/base-infrastructure/terraform/registry.tf
+++ b/base-infrastructure/terraform/registry.tf
@@ -1,0 +1,12 @@
+module "go_shared_registry" {
+  source = "./registry"
+
+  app_name            = "ifrcgo"
+  environment         = var.environment
+
+  pull_principal_ids  = [
+    module.resources.cluster_kubelet_identity
+  ]
+
+  resource_group_name = module.resources.resource_group
+}

--- a/base-infrastructure/terraform/registry.tf
+++ b/base-infrastructure/terraform/registry.tf
@@ -1,12 +1,12 @@
 module "go_shared_registry" {
-  source = "./registry"
+  source      = "./registry"
+  app_name    = "ifrcgo"
+  environment = var.environment
 
-  app_name            = "ifrcgo"
-  environment         = var.environment
-
-  pull_principal_ids  = [
+  pull_principal_ids = [
     module.resources.cluster_kubelet_identity
   ]
 
+  registry_sku        = "Standard"
   resource_group_name = module.resources.resource_group
 }

--- a/base-infrastructure/terraform/registry/ci_access.tf
+++ b/base-infrastructure/terraform/registry/ci_access.tf
@@ -1,0 +1,29 @@
+# These resources create credentials that can be used in CI Pipelines to push to the registry
+resource "azurerm_container_registry_scope_map" "ci" {
+  name = "${var.app_name}-${var.environment}-ci-scope-map"
+
+  actions = [
+    "repositories/*/content/read",
+    "repositories/*/content/write"
+  ]
+
+  container_registry_name = azurerm_container_registry.shared.name
+  description             = "Scope map for CI push actions"
+  resource_group_name     = data.azurerm_resource_group.app_rg.name
+}
+
+# Create an ACR token
+resource "azurerm_container_registry_token" "ci" {
+  name                    = "${var.app_name}-${var.environment}-ci-token"
+  container_registry_name = azurerm_container_registry.shared.name
+  resource_group_name     = data.azurerm_resource_group.app_rg.name
+  scope_map_id            = azurerm_container_registry_scope_map.ci.id
+}
+
+# Obtain the username and password for the token
+resource "azurerm_container_registry_token_password" "ci" {
+  container_registry_token_id = azurerm_container_registry_token.ci.id
+
+  password1 {
+  }
+}

--- a/base-infrastructure/terraform/registry/cluster_access_principals.tf
+++ b/base-infrastructure/terraform/registry/cluster_access_principals.tf
@@ -1,0 +1,7 @@
+# This resource is used to grant pull permissions to the supplied Azure identities
+resource "azurerm_role_assignment" "acr_pull" {
+  count                = length(var.pull_principal_ids)
+  scope                = azurerm_container_registry.shared.id
+  role_definition_name = "AcrPull" # Grants the "ACR pull" permission
+  principal_id         = var.pull_principal_ids[count.index]
+}

--- a/base-infrastructure/terraform/registry/data.tf
+++ b/base-infrastructure/terraform/registry/data.tf
@@ -1,0 +1,4 @@
+# Retrieve data on the resource group
+data "azurerm_resource_group" "app_rg" {
+  name = var.resource_group_name
+}

--- a/base-infrastructure/terraform/registry/main.tf
+++ b/base-infrastructure/terraform/registry/main.tf
@@ -1,0 +1,6 @@
+resource "azurerm_container_registry" "shared" {
+  name                = "${title(var.app_name)}${title(var.environment)}ContainerRegistry"
+  resource_group_name = data.azurerm_resource_group.app_rg.name
+  location            = data.azurerm_resource_group.app_rg.location
+  sku                 = var.registry_sku
+}

--- a/base-infrastructure/terraform/registry/outputs.tf
+++ b/base-infrastructure/terraform/registry/outputs.tf
@@ -1,0 +1,13 @@
+# Output container registry credentials
+output "acr_token_username" {
+  value = azurerm_container_registry_token.ci.name
+}
+
+output "acr_token_password" {
+  value     = azurerm_container_registry_token_password.ci.password1[0].value
+  sensitive = true
+}
+
+output "registry_server" {
+  value = azurerm_container_registry.shared.login_server
+}

--- a/base-infrastructure/terraform/registry/providers.tf
+++ b/base-infrastructure/terraform/registry/providers.tf
@@ -1,0 +1,12 @@
+provider "azurerm" {
+  features {}
+}
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.53.0"
+    }
+  }
+}

--- a/base-infrastructure/terraform/registry/variables.tf
+++ b/base-infrastructure/terraform/registry/variables.tf
@@ -1,0 +1,21 @@
+variable "app_name" {
+  type = string
+}
+
+variable "pull_principal_ids" {
+  type    = list(any)
+  default = []
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "registry_sku" {
+  type    = string
+  default = "Basic"
+}
+
+variable "resource_group_name" {
+  type = string
+}

--- a/base-infrastructure/terraform/resources/output.tf
+++ b/base-infrastructure/terraform/resources/output.tf
@@ -22,6 +22,10 @@ output "cluster_oidc_issuer_url" {
   value = azurerm_kubernetes_cluster.ifrcgo.oidc_issuer_url
 }
 
+output "cluster_kubelet_identity" {
+  value = azurerm_kubernetes_cluster.ifrcgo.kubelet_identity[0].object_id
+}
+
 output "resource_group" {
   value = data.azurerm_resource_group.ifrcgo.name
 }


### PR DESCRIPTION
### **PR Title**: Add Azure Container Registry (ACR) with AKS Integration  

### **Summary**  
This PR introduces an **Azure Container Registry (ACR)** with a **Standard SKU** and integrates it with the existing **AKS cluster** for seamless image pulls. Additionally, a **service principal access token** is created for GitHub Actions workflows with push permissions enabled.  

### Addresses #60 & #80

### **Changes**  
- **Created an Azure Container Registry (ACR)** with a **Standard SKU**.  
- **Configured AKS pull permissions** by assigning the `azurerm_kubernetes_cluster.ifrcgo.kubelet_identity[0].object_id` attribute to the ACR **role-based access control (RBAC)**, allowing the AKS kubelet identity to pull images without explicit secrets.  
- **Generated an ACR access token** with push permissions for use in **GitHub Actions workflows**.  

### **Why this is needed**  
- **Enhances security** by allowing AKS to pull images without storing credentials.  
- **Simplifies authentication** for GitHub Actions, enabling automated container image pushes to ACR.  
- **Ensures best practices** by leveraging Azure-native identity-based access management.  

### **Next Steps**  
- Update GitHub Actions workflows to use the ACR token for image pushes.  
- Validate AKS workloads successfully pull images from the registry. 
