### PR TITLE
[montandon-eoapi] make changes to values for passing secrets from vault

### DIFF
--- a/applications/argocd/staging/applications/montandon-eoapi.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://devseed.com/eoapi-k8s/
     chart: eoapi
-    targetRevision: 0.5.3-azure-test
+    targetRevision: v0.5.3-azure-test-sa
     helm:
       valuesObject:
         ingress:

--- a/applications/argocd/staging/applications/montandon-eoapi.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi.yaml
@@ -28,14 +28,14 @@ spec:
             pghost: DB_HOST
             dbname: DB_NAME
 
-        serviceAccount:
-          create: true
-          automount: true
-          annotations:
-            azure.workload.identity/client-id : "9b1f12a8-4ae9-4281-afa9-948451f77dce"
-          labels:
-            azure.workload.identity/use: "true"
-          name: "service-token-reader"
+          serviceAccount:
+            create: true
+            automount: true
+            annotations:
+              azure.workload.identity/client-id : "9b1f12a8-4ae9-4281-afa9-948451f77dce"
+            labels:
+              azure.workload.identity/use: "true"
+            name: "service-token-reader"
 
 
         pgstacBootstrap:

--- a/applications/argocd/staging/applications/montandon-eoapi.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi.yaml
@@ -24,9 +24,13 @@ spec:
             clientId: "9b1f12a8-4ae9-4281-afa9-948451f77dce"
             tenantId: "a2b53be5-734e-4e6c-ab0d-d184f60fd917"
           secretKeys:
-            pgpassword: DB_PASSWORD
-            pghost: DB_HOST
-            dbname: DB_NAME
+            DB_PASSWORD: POSTGRES_PASSWORD
+            DB_PASSWORD: PGPASSWORD
+            DB_HOST: POSTGRES_HOST
+            DB_HOST: POSTGRES_HOST_READER
+            DB_HOST: POSTGRES_HOST_WRITER
+            DB_NAME: POSTGRES_DB
+            DB_NAME: PGDATABASE
 
           serviceAccount:
             create: true

--- a/applications/argocd/staging/applications/montandon-eoapi.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi.yaml
@@ -10,6 +10,7 @@ spec:
   source:
     repoURL: https://devseed.com/eoapi-k8s/
     chart: eoapi
+    # TODO: replace with test version for azure secrets handling
     targetRevision: 0.5.0
     helm:
       valuesObject:
@@ -17,6 +18,19 @@ spec:
           host: "montandon-eoapi-stage.ifrc.org"
           tls:
             enabled: false
+      azure:
+        aksSecretsProviderAvailable: true
+        # TODO: fill these with correct values
+        keyvault:
+          name: ""
+          clientId: ""
+          tenantId: ""
+        # TODO: use correct key names based on how they are stored in the vault
+        secretKeys:
+          pgpassword: POSTGRES_PASSWORD
+          pghost: POSTGRES_HOST
+          dbname: POSTGRES_DBNAME
+
         pgstacBootstrap:
           settings:
             envVars:


### PR DESCRIPTION
We will need to use a version of `eoapi-k8s` published from this branch for this to work: https://github.com/developmentseed/eoapi-k8s/pull/187

We will need to fill in the correct values in the sections marked as `TODO`.

cc @geohacker @emmanuelmathot @sunu 