### PR TITLE
bump version of montandon-eoapi chart

### DIFF
--- a/applications/argocd/staging/applications/montandon-eoapi.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://devseed.com/eoapi-k8s/
     chart: eoapi
-    targetRevision: 0.5.3-azure-test-12
+    targetRevision: 0.5.3-azure-test-13
     helm:
       valuesObject:
         ingress:


### PR DESCRIPTION
bump version to include replacing of keyvault keys `_` with `-`

cc @geohacker @emmanuelmathot 