### PR TITLE
Explicitly pin ingress-nginx version to the latest 4.12.1

### DIFF
--- a/base-infrastructure/terraform/resources/helm-ingress-nginx.tf
+++ b/base-infrastructure/terraform/resources/helm-ingress-nginx.tf
@@ -3,6 +3,7 @@ resource "helm_release" "ifrcgo-ingress-nginx" {
   repository       = "https://kubernetes.github.io/ingress-nginx"
   chart            = "ingress-nginx"
   namespace        = "ingress-nginx"
+  version          = "4.12.1"
   create_namespace = true
   depends_on       = [
     azurerm_public_ip.ifrcgo


### PR DESCRIPTION
Fix for https://kubernetes.io/blog/2025/03/24/ingress-nginx-cve-2025-1974/