### PR TITLE
Change bitnami image repository to bitnamilegacy (prod)

### DIFF
--- a/applications/argocd/production/applications/alert-hub-backend.yaml
+++ b/applications/argocd/production/applications/alert-hub-backend.yaml
@@ -13,6 +13,12 @@ spec:
     targetRevision: 0.0.1-develop.041116e
     helm:
       valuesObject:
+        global:
+          security:
+            allowInsecureImages: true
+        redis:
+          image:
+            repository: bitnamilegacy/redis
         # NOTE: This should be adjusted in future to a value optimized for the workload
         # Vertical Pod Autoscaler should be used for establishing these values:
         # https://learn.microsoft.com/en-us/azure/aks/vertical-pod-autoscaler

--- a/applications/argocd/production/applications/sdt-api.yaml
+++ b/applications/argocd/production/applications/sdt-api.yaml
@@ -15,6 +15,12 @@ spec:
       valuesObject:
         fullnameOverride: ifrcgo-sdt
         environment: PROD
+        global:
+          security:
+            allowInsecureImages: true
+        redis:
+          image:
+            repository: bitnamilegacy/redis
         ingress:
           enabled: true
           host: surveydesigner-api.ifrc.org

--- a/applications/go-api/helm/ifrcgo-helm/values-production.yaml
+++ b/applications/go-api/helm/ifrcgo-helm/values-production.yaml
@@ -1,5 +1,9 @@
 environment: production
 
+global:
+  security:
+    allowInsecureImages: true
+
 env:
   API_FQDN: goadmin.ifrc.org
   AUTO_TRANSLATION_TRANSLATOR: lang.translation.IfrcTranslator
@@ -31,6 +35,8 @@ api:
       memory: 4Gi
 
 redis:
+  image:
+    repository: bitnamilegacy/redis
   resources:
     requests:
       cpu: "0.2"


### PR DESCRIPTION
Continue from:
- https://github.com/IFRCGo/go-deploy/pull/101

# Changes:
- Updated Bitnami image repository to `bitnamilegacy`


## 🚨🚨 After merging 🚨🚨
- [x] Wait for production argocd to sync
- [x] Restart all Celery workers
- [x] Merge changes into `master` to deploy `go-api`
- [x] Restart all Celery workers for `go-api`

> \[!IMPORTANT]
> Redis may have short downtime due to the image change. This can cause Celery workers to freeze.
> To avoid that, delete the pods to let new ones start.
