### PR TITLE
upgrade eoapi-k8s version for monty staging, add placeholder for queryables

### DIFF
--- a/applications/argocd/staging/applications/montandon-eoapi.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi.yaml
@@ -82,7 +82,10 @@ spec:
           # image:
           #   name: ghcr.io/stac-utils/pgstac
           #   tag: v0.9.5
-          queryables: []
+          queryables:
+            - file: "montandon-eoapi/queryables.json"
+              indexFields: ["monty:country_codes", "monty:corr_id", "monty:hazard_codes"]
+              deleteMissing: true
           settings:
             labels:
               azure.workload.identity/use: "true"

--- a/applications/argocd/staging/applications/montandon-eoapi/queryables.json
+++ b/applications/argocd/staging/applications/montandon-eoapi/queryables.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://example.com/stac/queryables",
+  "type": "object",
+  "title": "Queryables for Monty STAC API",
+  "description": "Queryable names for the Monty STAC API",
+  "properties": {
+    "id": {
+      "description": "Item identifier",
+      "type": "string"
+    },
+    "collection": {
+      "description": "Collection identifier",
+      "type": "string"
+    },
+    "datetime": {
+      "description": "Datetime",
+      "type": "string",
+      "format": "date-time"
+    },
+    "geometry": {
+      "description": "Geometry",
+      "type": "object"
+    },
+    "monty:episode_number": {
+      "description": "The episode number of the event",
+      "type": "integer"
+    },
+    "monty:country_codes": {
+      "description": "The country codes of the countries affected by the event, hazard, impact or response",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^([A-Z]{3})|AB9$"
+      }
+    },
+    "monty:corr_id": {
+      "description": "The unique identifier assigned by the Monty system to the reference event",
+      "type": "string"
+    },
+    "monty:hazard_codes": {
+      "description": "The hazard codes of the hazards affecting the event",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^([A-Z]{2}(?:\\d{4}$){0,1})|([a-z]{3}-[a-z]{3}-[a-z]{3}-[a-z]{3})|([A-Z]{2})$"
+      }
+    },
+    "roles": {
+      "description": "The roles of the item",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["event", "reference", "source", "hazard", "impact", "response"]
+      }
+    },
+    "monty:hazard_detail.severity_value": {
+      "description": "The estimated maximum hazard intensity/magnitude/severity value",
+      "type": "number"
+    },
+    "monty:hazard_detail.severity_unit": {
+      "description": "The unit of the severity value",
+      "type": "string"
+    },
+    "monty:hazard_detail.estimate_type": {
+      "description": "The type of the estimate",
+      "type": "string",
+      "enum": ["primary", "secondary", "modelled"]
+    },
+    "monty:impact_detail.category": {
+      "description": "The category of impact",
+      "type": "string",
+      "enum": [
+        "people",
+        "crops",
+        "women",
+        "men",
+        "children_0_4",
+        "children_5_9",
+        "children_10_14",
+        "children_15_19",
+        "adult_20_24",
+        "adult_25_29",
+        "adult_30_34",
+        "adult_35_39",
+        "adult_40_44",
+        "adult_45_49",
+        "adult_50_54",
+        "adult_55_59",
+        "adult_60_64",
+        "elderly",
+        "wheelchair_users",
+        "roads",
+        "railways",
+        "vulnerable_employment",
+        "buildings",
+        "reconstruction_costs",
+        "hospitals",
+        "schools",
+        "local_currency",
+        "global_currency",
+        "local_currency_adj",
+        "global_currency_adj",
+        "usd_uncertain",
+        "cattle",
+        "aid_general",
+        "ifrc_contribution",
+        "ifrc_requested",
+        "alertscore",
+        "households"
+      ]
+    },
+    "monty:impact_detail.type": {
+      "description": "The estimated value type of the impact",
+      "type": "string",
+      "enum": [
+        "unspecified",
+        "unaffected",
+        "damaged",
+        "destroyed",
+        "potentially_damaged",
+        "affected_total",
+        "affected_direct",
+        "affected_indirect",
+        "death",
+        "missing",
+        "injured",
+        "evacuated",
+        "relocated",
+        "assisted",
+        "shelter_emergency",
+        "shelter_temporary",
+        "shelter_longterm",
+        "in_need",
+        "targeted",
+        "disrupted",
+        "cost",
+        "homeless",
+        "displaced_internal",
+        "displaced_external",
+        "displaced_total",
+        "alertscore",
+        "potentially_affected",
+        "highest_risk"
+      ]
+    },
+    "monty:impact_detail.value": {
+      "description": "The estimated impact value",
+      "type": "number"
+    },
+    "monty:impact_detail.unit": {
+      "description": "The units of the impact estimate",
+      "type": "string"
+    },
+    "monty:impact_detail.estimate_type": {
+      "description": "The type of the estimate",
+      "type": "string",
+      "enum": ["primary", "secondary", "modelled"]
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
@emmanuelmathot am not sure how am supposed to specify / link to the queryables.json .

What I see:

An example for what the `queryables.json` should roughly look like: https://ifrcgo.org/monty-stac-extension/model/stac-api/queryables/

A rough example of where the `queryables` are defined in the `values.yaml`: https://github.com/developmentseed/eoapi-k8s/blob/main/charts/eoapi/values.yaml#L170

There the example shows pointing to a file with your `queryables.json` . @emmanuelmathot what I can't figure out is where I'm supposed to put that file and how to link to a reference to it? Or I might be misunderstanding things.

When you have a moment, could you try and clarify how exactly one passes in the `queryables.json` config? Then I can add it to this PR and figure out testing.

Thanks!