### PR TITLE
Increase AKS default node pool type to D8s v5

### DIFF
--- a/base-infrastructure/terraform/resources/aks.tf
+++ b/base-infrastructure/terraform/resources/aks.tf
@@ -16,7 +16,7 @@ resource "azurerm_kubernetes_cluster" "ifrcgo" {
 
   default_node_pool {
     name                        = "nodepool1"
-    vm_size                     = "Standard_DS3_v2"
+    vm_size                     = "Standard_D8s_v5"
     vnet_subnet_id              = azurerm_subnet.aks.id
     enable_auto_scaling         = true
     min_count                   = 1


### PR DESCRIPTION
We could change recent pool type, and later decrease 7 vm-s to 4.
This way the allocatable memory will grow from 80 to 120GiB, and the monthly price will decrease:
7 nodes, DS3_v2: $191.99 × 7 = $1,343.93 → ~CHF 1210
4 nodes, D8s_v5: $312.44 × 4 = $1,249.76 → ~CHF 1125

(Maybe 3 nodes would be also enough with 90GiB and CHF 844, we'll see.)