### PR TITLE
upgrade stac-auth-proxy to v1.1.1

### DIFF
--- a/applications/argocd/production/applications/montandon-eoapi/application.yaml
+++ b/applications/argocd/production/applications/montandon-eoapi/application.yaml
@@ -132,16 +132,17 @@ spec:
           UPSTREAM_URL: "http://montandon-eoapi-stac:8080"
           # UPSTREAM_URL: "https://montandon-eoapi.ifrc.org/stac"
           OIDC_DISCOVERY_URL: "https://goadmin.ifrc.org/o/.well-known/openid-configuration"
+          OIDC_DISCOVERY_INTERNAL_URL: "https://goadmin.ifrc.org/o/.well-known/openid-configuration"
           OVERRIDE_HOST: "0"
           ROOT_PATH: "/stac"
           COLLECTIONS_FILTER_CLS: stac_auth_proxy.montandon_filters:CollectionsFilter
           ITEMS_FILTER_CLS: stac_auth_proxy.montandon_filters:ItemsFilter
         ingress:
-          enabled: "true"
+          enabled: true
           host: "montandon-eoapi.ifrc.org"
           className: "nginx"
           tls:
-            enabled: "true"
+            enabled: true
             secretName: "montandon-eoapi-helm-secret-cert"
         replicaCount: 1
         extraVolumes:

--- a/applications/argocd/production/applications/montandon-eoapi/application.yaml
+++ b/applications/argocd/production/applications/montandon-eoapi/application.yaml
@@ -114,7 +114,7 @@ spec:
             keyvaultName: montandon-eoapi-producti
 
   - repoURL: https://github.com/developmentseed/stac-auth-proxy.git
-    targetRevision: v1.0.3
+    targetRevision: v1.1.1
     path: helm/
     helm:
       valuesObject:

--- a/applications/argocd/staging/applications/montandon-eoapi/application.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi/application.yaml
@@ -132,16 +132,17 @@ spec:
           UPSTREAM_URL: "http://montandon-eoapi-stac:8080"
           # UPSTREAM_URL: "https://montandon-eoapi-stage.ifrc.org/stac"
           OIDC_DISCOVERY_URL: "https://goadmin.ifrc.org/o/.well-known/openid-configuration"
+          OIDC_DISCOVERY_INTERNAL_URL: "https://goadmin.ifrc.org/o/.well-known/openid-configuration"
           OVERRIDE_HOST: "0"
           ROOT_PATH: "/stac"
           COLLECTIONS_FILTER_CLS: stac_auth_proxy.montandon_filters:CollectionsFilter
           ITEMS_FILTER_CLS: stac_auth_proxy.montandon_filters:ItemsFilter
         ingress:
-          enabled: "true"
+          enabled: true
           host: "montandon-eoapi-stage.ifrc.org"
           className: "nginx"
           tls:
-            enabled: "true"
+            enabled: true
             secretName: "montandon-eoapi-helm-secret-cert"
         replicaCount: 1
         extraVolumes:

--- a/applications/argocd/staging/applications/montandon-eoapi/application.yaml
+++ b/applications/argocd/staging/applications/montandon-eoapi/application.yaml
@@ -114,7 +114,7 @@ spec:
             keyvaultName: montandon-eoapi-staging
 
   - repoURL: https://github.com/developmentseed/stac-auth-proxy.git
-    targetRevision: v1.0.3
+    targetRevision: v1.1.1
     path: helm/
     helm:
       valuesObject:


### PR DESCRIPTION
We need to upgrade stac-auth-proxy to v1.1.1 as it includes a fix for a recent vulnerability in Starlette.

I _think_ we should just be able to bump this version for now and have things work, but would be good to deploy and test.

I was unable to create a working PoC of bypassing authentication for our current setup, but I have been able to get a PoC working locally against unpatched versions of stac-auth-proxy.

@pantierra - I think we should eventually change how we are setting up stac-auth-proxy? I think there's a better way to do it now that it's packaged with eoapi-k8s? But I think we can treat that separately and for now just apply the version bump patch?

cc @emmanuelmathot @thenav56 